### PR TITLE
fix bug in merge_kernel for structural_reparam

### DIFF
--- a/replknet.py
+++ b/replknet.py
@@ -118,7 +118,8 @@ class ReparamLargeKernelConv(nn.Module):
         self.lkb_reparam = get_conv2d(in_channels=self.lkb_origin.conv.in_channels,
                                      out_channels=self.lkb_origin.conv.out_channels,
                                      kernel_size=self.lkb_origin.conv.kernel_size, stride=self.lkb_origin.conv.stride,
-                                     padding=self.lkb_origin.conv.padding, dilation=self.lkb_origin.conv.dilation,
+                                     # padding is needed here to make sure the output size is the same as the original large kernel conv
+                                     padding=self.lkb_origin.conv.kernel_size // 2, dilation=self.lkb_origin.conv.dilation,
                                      groups=self.lkb_origin.conv.groups, bias=True)
         self.lkb_reparam.weight.data = eq_k
         self.lkb_reparam.bias.data = eq_b


### PR DESCRIPTION
When applying model.structural_reparam(), there is a need to add padding in nn.Conv2d, see #48 .